### PR TITLE
Remove backslash escape of pipe in sed command.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ for fn in `cat packages.txt`; do
     sed -i '/^$/{N;/^\n$/d;}' $fn/meta.yaml
     sed -i '/^$/{N;/^\n$/d;}' $fn/build.sh
     sed -i 's/ + file LICENSE//' $fn/meta.yaml
-    sed -i 's/ \| file LICENSE//' $fn/meta.yaml
+    sed -i 's/ | file LICENSE//' $fn/meta.yaml
     if grep -lq "\- gcc"  $fn/meta.yaml ; then sed  -i 's/run:/run:\n   - libgcc  # [not win]/' $fn/meta.yaml ; fi
     # skip win builds
     sed -i 's/number: 0/number: 0\n  skip: true  # [win32]/g' $fn/meta.yaml


### PR DESCRIPTION
I was using this script to prepare R packages for conda and noticed that "| file LICENSE" was not removed. I removed the backslash in front of the pipe command, and that seemed to fix things.

```
# with backslash
$ echo " license: GPL-3 | file LICENSE" | sed 's/ \| file LICENSE//'
license: GPL-3 | file LICENSE
# without backslash
$ echo " license: GPL-3 | file LICENSE" | sed 's/ | file LICENSE//'
 license: GPL-3
# some system information
$ bash --version | head -n 1
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
$ sed --version | head -n 1
sed (GNU sed) 4.2.2
```

Thanks for writing this script and for all your work maintaining R packages on conda-forge!