### PR TITLE
Proposed changes to osx

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,29 +4,37 @@ mkdir -p tmp
 for fn in `cat packages.txt`; do
     conda skeleton cran $fn
     cp $fn/meta.yaml tmp/$fn.meta.yaml
-    sed -i '/^\s*#.*$/ d' $fn/meta.yaml
-    sed -i '/^mv\s.*$/ d' $fn/build.sh
-    sed -i '/^grep\s.*$/ d' $fn/build.sh
-    sed -i '/^#\s.*$/ d' $fn/build.sh
-    sed -i '/^@.*$/ d' $fn/bld.bat
-    sed -i '/^$/{N;/^\n$/d;}' $fn/meta.yaml
-    sed -i '/^$/{N;/^\n$/d;}' $fn/build.sh
-    sed -i 's/ [+|] file LICEN[SC]E//' $fn/meta.yaml
-    sed  -i 's/{indent}/\n    - /' $fn/meta.yaml
+    sed -i.bak '/^[[:space:]]*#.*$/ d' $fn/meta.yaml
+    sed -i.bak '/^mv[[:space:]].*$/ d' $fn/build.sh
+    sed -i.bak '/^grep[[:space:]].*$/ d' $fn/build.sh
+    sed -i.bak '/^#[[:space:]].*$/ d' $fn/build.sh
+    sed -i.bak '/^@.*$/ d' $fn/bld.bat
+    sed -i.bak '/^$/{N;/^\n$/d;}' $fn/meta.yaml
+    sed -i.bak '/^$/{N;/^\n$/d;}' $fn/build.sh
+    sed -i.bak 's/ [+|] file LICEN[SC]E//' $fn/meta.yaml
+    sed  -i.bak 's/{indent}/\
+    - /' $fn/meta.yaml # Ridiculous POPSIX-stable way to get newline:(
     # skip win builds
-    sed -i 's/number: 0/number: 0\n  skip: true  # [win32]/g' $fn/meta.yaml
+    sed -i.bak 's/number: 0/number: 0\
+  skip: true  # [win32]/g' $fn/meta.yaml
 
     # Add GPL-3
-    sed -i s/"  license_family: GPL3"/"  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  # [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-3'  # [win]"/ $fn/meta.yaml
+    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\[[:space:]]hare\\\licenses\\\GPL-3' \# [win]/" $fn/meta.yaml
     # Add GPL-2
-    sed -i s/"  license_family: GPL2"/"  license_family: GPL2\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'  # [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-2'  # [win]"/ $fn/meta.yaml
+    sed -i.bak 's/  license_family: GPL2/  license_family: GPL2\
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'"'"'  \# [unix]\
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\[[:space:]]hare\\\licenses\\\GPL-2'"'"'  \# [win]/' $fn/meta.yaml
 
-    sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $fn/bld.bat
-    sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $fn/meta.yaml
-    sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $fn/build.sh
+    sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/bld.bat
+    sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/meta.yaml
+    sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/build.sh
     cat extra.yaml >> $fn/meta.yaml
-    gedit $fn/meta.yaml
+    if [[ $(uname -s) == "Linux" ]]; then
+	gedit $fn/meta.yaml
+    fi
     diff -u $fn/meta.yaml tmp/$fn.meta.yaml > tmp/$fn.meta.diff
+
+    rm -f $fn/*.bak
 done
 
 

--- a/run.sh
+++ b/run.sh
@@ -19,11 +19,11 @@ for fn in `cat packages.txt`; do
   skip: true  # [win32]/g' $fn/meta.yaml
 
     # Add GPL-3
-    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\[[:space:]]hare\\\licenses\\\GPL-3' \# [win]/" $fn/meta.yaml
+    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-3' \# [win]/" $fn/meta.yaml
     # Add GPL-2
     sed -i.bak 's/  license_family: GPL2/  license_family: GPL2\
   license_file: '"'"'{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'"'"'  \# [unix]\
-  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\[[:space:]]hare\\\licenses\\\GPL-2'"'"'  \# [win]/' $fn/meta.yaml
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-2'"'"'  \# [win]/' $fn/meta.yaml
 
     sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/bld.bat
     sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/meta.yaml


### PR DESCRIPTION
These proposed changes seems to work on my MacBook Pro MacOSX 10.13.3. The main changes have to do with making sed commands working with FreeBSD sed.  I can't guarantee that all cahnges are POSIX-compliant, but when claims were found for posix compliance, these solutions were chosen over others (e.g., for newlines in sed). Single quotes in the license string was tricky -- these conflicted with use of single quotes arund the sed s-staement, but the obvious alternative, which was to use double quotes around the sed s-statement, caused substitution to newlines not to work -- almost a catch22 situation. I'm not sure how portable the chosen solution ('switching to double quotes in the middle of the statement to handel the single quotes and then switchingback') is.  The sed option '-i.bak' creates backup files which are removed at the end of the loop. I made the call to gedit conditional on linux env, as suggested by John Blischak; an alternative could be to make use of system variable 'EDITOR' to select which editor to call. There might have been some other small tweaks.

Hope this can be of help. Please check if it works on your linux/unix/windows systems.