### PR TITLE
Fix license path issues

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,2 +1,3 @@
 r-tilegramsr
 r-udunits2
+r-usethis

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ for fn in `cat packages.txt`; do
   skip: true  # [win32]/g' $fn/meta.yaml
 
     # Add GPL-3
-    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-3' \# [win]/" $fn/meta.yaml
+    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-3'  \# [win]/" $fn/meta.yaml
     # Add GPL-2
     sed -i.bak 's/  license_family: GPL2/  license_family: GPL2\
   license_file: '"'"'{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'"'"'  \# [unix]\

--- a/run.sh
+++ b/run.sh
@@ -18,12 +18,24 @@ for fn in `cat packages.txt`; do
     sed -i.bak 's/number: 0/number: 0\
   skip: true  # [win32]/g' $fn/meta.yaml
 
-    # Add GPL-3
-    sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-3'  \# [win]/" $fn/meta.yaml
-    # Add GPL-2
-    sed -i.bak 's/  license_family: GPL2/  license_family: GPL2\
+    if [[ $(uname -s) == "Linux" ]]; then
+        # Add GPL-3
+	sed -i.bak "s/  license_family: GPL3/  license_family: GPL3\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-3'  \# [win]/" $fn/meta.yaml
+	# Add GPL-2
+	sed -i.bak "s/  license_family: GPL2/  license_family: GPL2\n  license_file: '{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'  \# [unix]\n  license_file: '{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-2'  \# [win]/" $fn/meta.yaml
+    elif [[ $(uname -s) == "Darwin" ]]; then
+        # Add GPL-3
+        sed -i.bak 's/  license_family: GPL3/  license_family: GPL3\
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-3'"'"'  \# [unix]\
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-3'"'"'  \# [win]/' $fn/meta.yaml
+        # Add GPL-2
+        sed -i.bak 's/  license_family: GPL2/  license_family: GPL2\
   license_file: '"'"'{{ environ[\"PREFIX\"] }}\/lib\/R\/share\/licenses\/GPL-2'"'"'  \# [unix]\
-  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\share\\\licenses\\\GPL-2'"'"'  \# [win]/' $fn/meta.yaml
+  license_file: '"'"'{{ environ[\"PREFIX\"] }}\\\R\\\share\\\licenses\\\GPL-2'"'"'  \# [win]/' $fn/meta.yaml
+    else
+	echo "This script only supports Linux and macOS"
+	exit 1
+    fi
 
     sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/bld.bat
     sed -i.bak -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' $fn/meta.yaml


### PR DESCRIPTION
Our testing of #10 wasn't sufficient. There were two different strategies for adding the GPL license, one used for GPL-3 (which worked on Linux but not macOS) and one for GPL-2 (which worked for macOS but not Linux). I didn't notice these issues because it affected the Windows path to the license file, and I only tested building recipes on Linux and macOS.

Also, there was a linting error for insufficient spaces before one of the selectors. I learned about the Windows error and the linting error in https://github.com/conda-forge/staged-recipes/pull/5215

I tried unifying the two solutions, but everytime I made a change to get it to work on one OS, it would inevitably fail on the other. Thus I gave up and just have the script use the solution that works for whatever OS it is run on. I also added a package with a GPL-3 license for any future testing.

I'd like to merge this ASAP, especially because this repo is now displayed in the online conda-forge docs.

cc: @bgruening @bsennblad

And a long-term question: Should we just use this strategy of having separate sed commands for the entire script? Perhaps that would make it more readable?