### PR TITLE
Update for conda-build 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ process. Also, please only submit one recipe per Pull Request.
 
 ## Installation
 
-You will need conda and conda-build 2 installed. To install conda-build 2
-instead of 3, run the following:
+You will need conda and conda-build 3 installed:
 
 ```
-conda install -c conda-forge conda-build=2
+conda install -c conda-forge conda-build
 ```
 
 To use the Python script `run.py`, you will need to install Python 3.


### PR DESCRIPTION
This PR updates the helper script to be compatible with conda-build 3. See #14 for discussion. It is not backwards compatible with conda-build 2.

cc @bgruening @daler @cbrueffer @bsennblad

Here are the results for `r-usethis` using the helper script with conda-build  3.10.1:

**meta.yaml**

```
{% set version = '1.3.0' %}
{% set posix = 'm2-' if win else '' %}
{% set native = 'm2w64-' if win else '' %}

package:
  name: r-usethis
  version: {{ version|replace("-", "_") }}

source:
  fn: usethis_{{ version }}.tar.gz
  url:
    - {{ cran_mirror }}/src/contrib/usethis_{{ version }}.tar.gz
    - {{ cran_mirror }}/src/contrib/Archive/usethis/usethis_{{ version }}.tar.gz
  sha256: a2b3fcb3f75a39d2d46bfca7478f4e6787c9cc59ec4a53a1ce5bea8891bbc164

build:
  number: 0
  skip: true  # [win32]
  rpaths:
    - lib/R/lib/
    - lib/

requirements:
  build:
  host:
    - r-base
    - r-backports >=1.1.0
    - r-clipr
    - r-clisymbols
    - r-crayon
    - r-curl >=2.7
    - r-desc
    - r-gh
    - r-git2r
    - r-httr
    - r-rematch2
    - r-rmarkdown
    - r-rprojroot
    - r-rstudioapi
    - r-styler
    - r-whisker
  run:
    - r-base
    - r-backports >=1.1.0
    - r-clipr
    - r-clisymbols
    - r-crayon
    - r-curl >=2.7
    - r-desc
    - r-gh
    - r-git2r
    - r-httr
    - r-rematch2
    - r-rmarkdown
    - r-rprojroot
    - r-rstudioapi
    - r-styler
    - r-whisker

test:
  commands:
    - $R -e "library('usethis')"           # [not win]
    - "\"%R%\" -e \"library('usethis')\""  # [win]

about:
  home: https://github.com/r-lib/usethis
  license: GPL-3
  summary: Automate package and project setup tasks that are otherwise performed manually. This
    includes setting up unit testing, test  coverage, continuous integration, Git, 'GitHub',
    licenses, 'Rcpp', 'RStudio'  projects, and more.
  license_family: GPL3
  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]

extra:
  recipe-maintainers:
    - johanneskoester
    - bgruening
    - daler
    - jdblischak
    - cbrueffer
```

**build.sh**

```
#!/bin/bash
if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
  export DISABLE_AUTOBREW=1
  $R CMD INSTALL --build .
else
  mkdir -p $PREFIX/lib/R/library/usethis
  mv * $PREFIX/lib/R/library/usethis
fi
```


**bld.bat**

```
"%R%" CMD INSTALL --build .
IF %ERRORLEVEL% NEQ 0 exit 1
```

I didn't try to manipulate the Jinja2 variable `cran_mirror` because that is currently in flux. See https://github.com/conda/conda-build/issues/2863#issuecomment-385989845 and https://github.com/conda/conda-build/pull/2868