### PR TITLE
Fix linting for noarch recipes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# conda skeleton
+.web_cache/
+
+# conda R recipes
+r-*

--- a/run.R
+++ b/run.R
@@ -84,6 +84,17 @@ for (fn in packages) {
   # Remove comments
   meta_new <- meta_new[!str_detect(meta_new, "^\\s*#")]
 
+  # If it is a noarch recipe, remove {{posix}}zip from build section.
+  #
+  # Motivation: linter fails if selector detected in requirements section of a
+  # noarch recipe.
+  is_noarch <- any(str_detect(meta_new, "  noarch: generic"))
+  if (is_noarch) {
+    meta_new <- str_replace(meta_new,
+                            "    - \\{\\{posix\\}\\}zip               # \\[win\\]",
+                            "")
+  }
+
   # Remove "+ file LICENSE" or "+ file LICENCE"
   meta_new <- str_replace(meta_new, " [+|] file LICEN[SC]E", "")
 

--- a/run.py
+++ b/run.py
@@ -96,7 +96,6 @@ for fn in packages:
         is_noarch = False
 
         for line in f:
-
             # Remove comments and blank lines
             if re.match('^\s*#', line) or re.match('^\n$', line):
                 continue
@@ -105,23 +104,22 @@ for fn in packages:
             #
             # Motivation: linter fails if selector detected in requirements section of a
             # noarch recipe.
-            if re.match("  noarch: generic", line):
+            if "  noarch: generic" in line:
                 is_noarch = True
             if is_noarch:
-                line =  re.sub("    - \\{\\{posix\\}\\}zip               # \\[win\\]",
-                               "", line)
+                line = line.replace("    - \\{\\{posix\\}\\}zip               # \\[win\\]", "")
 
             # Remove '+ file LICENSE' or '+ file LICENCE'
-            line = re.sub(' [+|] file LICEN[SC]E', '', line)
+            line = line.replace(' [+|] file LICEN[SC]E', '')
 
             # Add path to copy GPL-2 license shipped with r-base
-            line = re.sub('  license_family: GPL2', '\n'.join(gpl2), line)
+            line = line.replace('  license_family: GPL2', '\n'.join(gpl2))
 
             # Add path to copy GPL-3 license shipped with r-base
-            line = re.sub('  license_family: GPL3', '\n'.join(gpl3), line)
+            line = line.replace('  license_family: GPL3', '\n'.join(gpl3))
 
             # Add a blank line before a new section
-            line = re.sub('^[a-z]', '\n\g<0>', line)
+            line = line.replace('^[a-z]', '\n\g<0>')
 
             meta_new += line
 

--- a/run.py
+++ b/run.py
@@ -93,12 +93,23 @@ for fn in packages:
     meta_fname = os.path.join(fn, 'meta.yaml')
     with open(meta_fname, 'r') as f:
         meta_new = []
+        is_noarch = False
 
         for line in f:
 
             # Remove comments and blank lines
             if re.match('^\s*#', line) or re.match('^\n$', line):
                 continue
+
+            # If it is a noarch recipe, remove {{posix}}zip from build section.
+            #
+            # Motivation: linter fails if selector detected in requirements section of a
+            # noarch recipe.
+            if re.match("  noarch: generic", line):
+                is_noarch = True
+            if is_noarch:
+                line =  re.sub("    - \\{\\{posix\\}\\}zip               # \\[win\\]",
+                               "", line)
 
             # Remove '+ file LICENSE' or '+ file LICENCE'
             line = re.sub(' [+|] file LICEN[SC]E', '', line)


### PR DESCRIPTION
Close #27.

cc: @bgruening @isuruf

For noarch packages (e.g. r-tilegramsr, r-usethis), this results in an empty build section in requirements. For compiled packages (e.g. r-udunits2), the `{{posix}}zip` in the build section is left as is.