### PR TITLE
Fix regexes in Python script.

### DIFF
--- a/run.py
+++ b/run.py
@@ -110,7 +110,7 @@ for fn in packages:
                 line = line.replace("    - \\{\\{posix\\}\\}zip               # \\[win\\]", "")
 
             # Remove '+ file LICENSE' or '+ file LICENCE'
-            line = line.replace(' [+|] file LICEN[SC]E', '')
+            line = re.sub(' [+|] file LICEN[SC]E', '', line)
 
             # Add path to copy GPL-2 license shipped with r-base
             line = line.replace('  license_family: GPL2', '\n'.join(gpl2))
@@ -119,7 +119,7 @@ for fn in packages:
             line = line.replace('  license_family: GPL3', '\n'.join(gpl3))
 
             # Add a blank line before a new section
-            line = line.replace('^[a-z]', '\n\g<0>')
+            line = re.sub('^[a-z]', '\n\g<0>', line)
 
             meta_new += line
 


### PR DESCRIPTION
@bgruening This is a follow up to PR #28. I agree that there were multiple places where I was unnecessarily using a regular expression when a simple string substitution is sufficient. However, the string method `replace` does not accept regular expressions (at least as is currently implemented in this script). Thus `+ file LICENSE` is no longer removed, and the blank lines between sections are not added. This PR converts these two substitutions back to `re.sub`.