### PR TITLE
Fix removal of zip dependency in Python script.

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,7 +107,7 @@ for fn in packages:
             if "  noarch: generic" in line:
                 is_noarch = True
             if is_noarch:
-                line = line.replace("    - \\{\\{posix\\}\\}zip               # \\[win\\]", "")
+                line = line.replace("    - {{posix}}zip               # [win]", "")
 
             # Remove '+ file LICENSE' or '+ file LICENCE'
             line = re.sub(' [+|] file LICEN[SC]E', '', line)


### PR DESCRIPTION
It was still using a regex from re.sub, but line.replace does not use regexes.

xref: #28, https://github.com/conda-forge/staged-recipes/pull/7209#issuecomment-445520925, https://github.com/bgruening/conda_r_skeleton_helper/commit/2cb3f05eafc18debb86541a38996dd1ee3b261bd#diff-6e38f16215ae91c11fc5c54b74c66d54L111
