### PR TITLE
Append original CRAN metadata to recipe.

### DIFF
--- a/run.R
+++ b/run.R
@@ -81,6 +81,11 @@ for (fn in packages) {
   meta_raw <- readLines(meta_fname)
   meta_new <- meta_raw
 
+  # Extract CRAN metadata
+  cran_metadata_start <- which(meta_new == "# The original CRAN metadata for this package was:")
+  cran_metadata <- meta_new[cran_metadata_start:length(meta_new)]
+  cran_metadata <- cran_metadata[str_detect(cran_metadata, "^#\\s[A-Z]\\S+:")]
+
   # Remove comments
   meta_new <- meta_new[!str_detect(meta_new, "^\\s*#")]
 
@@ -130,6 +135,9 @@ for (fn in packages) {
   if (meta_new[sha256_line - 1] == "") {
     meta_new <- meta_new[-(sha256_line - 1)]
   }
+
+  # Add back CRAN metadata
+  meta_new <- c(meta_new, "", cran_metadata)
 
   writeLines(meta_new, meta_fname)
 

--- a/run.py
+++ b/run.py
@@ -94,8 +94,16 @@ for fn in packages:
     with open(meta_fname, 'r') as f:
         meta_new = []
         is_noarch = False
+        is_cran_metadata = False
+        cran_metadata = ['\n']
 
         for line in f:
+            # Extract CRAN metadata
+            if "original CRAN metadata" in line:
+                is_cran_metadata = True
+            if is_cran_metadata and re.match('^#\s[A-Z]\S+:', line):
+                cran_metadata += line
+
             # Remove comments and blank lines
             if re.match('^\s*#', line) or re.match('^\n$', line):
                 continue
@@ -126,6 +134,9 @@ for fn in packages:
     with open('extra.yaml', 'r') as f:
         maintainers = f.readlines()
     meta_new += maintainers
+
+    # Add back CRAN metadata
+    meta_new += cran_metadata
 
     with open(meta_fname, 'w') as f:
         f.writelines(meta_new)


### PR DESCRIPTION
To address #25, this PR extracts the original CRAN metadata and inserts it after the maintainer list.

cc: @mingwandroid @bgruening

As an example, the bottom of the `meta.yaml` for r-usethis would be:

```
extra:
  recipe-maintainers:
    - johanneskoester
    - bgruening
    - daler
    - jdblischak
    - cbrueffer
    - dbast

# Package: usethis
# Title: Automate Package and Project Setup
# Version: 1.4.0
# Authors@R: c( person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre"),  comment = c(ORCID = "0000-0003-4757-117X") ), person("Jennifer", "Bryan", , "jenny@rstudio.com", role = "aut", comment = c(ORCID = "0000-0002-6983-2759") ), person("RStudio", role = c("cph", "fnd")) )
# Description: Automate package and project setup tasks that are otherwise performed manually. This includes setting up unit testing, test  coverage, continuous integration, Git, 'GitHub', licenses, 'Rcpp', 'RStudio'  projects, and more.
# License: GPL-3
# URL: https://github.com/r-lib/usethis
# BugReports: https://github.com/r-lib/usethis/issues
# Depends: R (>= 3.1)
# Imports: clipr (>= 0.3.0), clisymbols, crayon, curl (>= 2.7), desc, fs (>= 1.2.0), gh, git2r (>= 0.23), glue, rlang, rprojroot (>= 1.2), rstudioapi, utils, whisker
# Suggests: covr, knitr, magick, rmarkdown, roxygen2, spelling (>= 1.2), styler (>= 1.0.2), testthat (>= 2.0.0), withr
# Encoding: UTF-8
# Language: en-US
# LazyData: true
# RoxygenNote: 6.1.0
# NeedsCompilation: no
# Packaged: 2018-08-14 05:17:52 UTC; jenny
# Author: Hadley Wickham [aut, cre] (<https://orcid.org/0000-0003-4757-117X>), Jennifer Bryan [aut] (<https://orcid.org/0000-0002-6983-2759>), RStudio [cph, fnd]
# Maintainer: Hadley Wickham <hadley@rstudio.com>
# Repository: CRAN
# Date/Publication: 2018-08-14 12:10:02 UTC
```