### PR TITLE
Default skeleton now adds license file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ process. Also, please only submit one recipe per Pull Request.
 
 ## Installation
 
-You will need conda and conda-build 3 (3.11.0+) installed:
+You will need conda and conda-build 3 (3.17.2+) installed:
 
 ```
 conda install -c conda-forge conda-build

--- a/run.R
+++ b/run.R
@@ -40,8 +40,8 @@ if (!grepl(pattern = "conda-build 3.+", conda_build_version)) {
 
 conda_build_version_num <- str_extract(conda_build_version,
                                        "\\d+\\.\\d+\\.\\d+")
-if (compareVersion(conda_build_version_num, "3.11.0") == -1) {
-  stop("You need to install conda-build 3.11.0 or later.",
+if (compareVersion(conda_build_version_num, "3.17.2") == -1) {
+  stop("You need to install conda-build 3.17.2 or later.",
        "\nCurrently installed version: ", conda_build_version_num,
        "\nRun: conda install -c conda-forge conda-build")
 }
@@ -102,20 +102,6 @@ for (fn in packages) {
 
   # Remove "+ file LICENSE" or "+ file LICENCE"
   meta_new <- str_replace(meta_new, " [+|] file LICEN[SC]E", "")
-
-  # Add path to copy GPL-3 license shipped with r-base
-  gpl3 <- c(
-    "  license_family: GPL3",
-    "  license_file: '{{ environ[\"PREFIX\"] }}/lib/R/share/licenses/GPL-3'")
-  meta_new <- str_replace(meta_new, "  license_family: GPL3",
-                          paste(gpl3, collapse = "\n"))
-
-  # Add path to copy GPL-2 license shipped with r-base
-  gpl2 <- c(
-    "  license_family: GPL2",
-    "  license_file: '{{ environ[\"PREFIX\"] }}/lib/R/share/licenses/GPL-2'")
-  meta_new <- str_replace(meta_new, "  license_family: GPL2",
-                          paste(gpl2, collapse = "\n"))
 
   # Add maintainers listed in extra.yaml
   maintainers <- readLines("extra.yaml")

--- a/run.py
+++ b/run.py
@@ -43,9 +43,9 @@ if not re.match('^3.+', conda_build_version):
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)
 
-v_min = StrictVersion('3.11.0')
+v_min = StrictVersion('3.17.2')
 if StrictVersion(conda_build_version) < v_min:
-    sys.stderr.write('You need to install conda-build 3.11.0 or later.\n')
+    sys.stderr.write('You need to install conda-build 3.17.2 or later.\n')
     sys.stderr.write('Currently installed version: %s\n'%(conda_build_version))
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)
@@ -84,12 +84,6 @@ for fn in packages:
 
     # Edit meta.yaml -------------------------------------------------------------
 
-    # license_file text for GPL'd packages
-    gpl2 = ['  license_family: GPL2',
-            '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'']
-    gpl3 = ['  license_family: GPL3',
-            '  license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'']
-
     meta_fname = os.path.join(fn, 'meta.yaml')
     with open(meta_fname, 'r') as f:
         meta_new = []
@@ -118,12 +112,6 @@ for fn in packages:
                 line = line.replace("    - {{posix}}zip               # [win]", "")
             # Remove '+ file LICENSE' or '+ file LICENCE'
             line = re.sub(' [+|] file LICEN[SC]E', '', line)
-
-            # Add path to copy GPL-2 license shipped with r-base
-            line = line.replace('  license_family: GPL2', '\n'.join(gpl2))
-
-            # Add path to copy GPL-3 license shipped with r-base
-            line = line.replace('  license_family: GPL3', '\n'.join(gpl3))
 
             # Add a blank line before a new section
             line = re.sub('^[a-z]', '\n\g<0>', line)


### PR DESCRIPTION
I added support for adding the license files to `conda-build` in https://github.com/conda/conda-build/pull/3284. This new behavior was released in conda-build 3.17.2 ([changelog](https://github.com/conda/conda-build/blob/3.17.2/CHANGELOG.txt#L8)). conda-forge has conda-build 3.17.3 and 3.17.4 available on [Anaconda Cloud](https://anaconda.org/conda-forge/conda-build/files) (note to myself: 3.17.2 wasn't built b/c 3.17.3 was released shortly afterwards https://github.com/conda-forge/conda-build-feedstock/pull/81).