### PR TITLE
Revert removal of zip for noarch win builds.

### DIFF
--- a/run.R
+++ b/run.R
@@ -89,17 +89,6 @@ for (fn in packages) {
   # Remove comments
   meta_new <- meta_new[!str_detect(meta_new, "^\\s*#")]
 
-  # If it is a noarch recipe, remove {{posix}}zip from build section.
-  #
-  # Motivation: linter fails if selector detected in requirements section of a
-  # noarch recipe.
-  is_noarch <- any(str_detect(meta_new, "  noarch: generic"))
-  if (is_noarch) {
-    meta_new <- str_replace(meta_new,
-                            "    - \\{\\{posix\\}\\}zip               # \\[win\\]",
-                            "")
-  }
-
   # Remove "+ file LICENSE" or "+ file LICENCE"
   meta_new <- str_replace(meta_new, " [+|] file LICEN[SC]E", "")
 

--- a/run.py
+++ b/run.py
@@ -87,7 +87,6 @@ for fn in packages:
     meta_fname = os.path.join(fn, 'meta.yaml')
     with open(meta_fname, 'r') as f:
         meta_new = []
-        is_noarch = False
         is_cran_metadata = False
         cran_metadata = ['\n']
 
@@ -102,14 +101,6 @@ for fn in packages:
             if re.match('^\s*#', line) or re.match('^\n$', line):
                 continue
 
-            # If it is a noarch recipe, remove {{posix}}zip from build section.
-            #
-            # Motivation: linter fails if selector detected in requirements section of a
-            # noarch recipe.
-            if "  noarch: generic" in line:
-                is_noarch = True
-            if is_noarch:
-                line = line.replace("    - {{posix}}zip               # [win]", "")
             # Remove '+ file LICENSE' or '+ file LICENCE'
             line = re.sub(' [+|] file LICEN[SC]E', '', line)
 


### PR DESCRIPTION
Now that PR https://github.com/conda-forge/conda-smithy/pull/966 has been merged, the linter now ignores selectors in build requirements. This new behavior will be live once a new version of conda-smithy is released.

xref: #27, #28, https://github.com/conda-forge/conda-forge.github.io/issues/683, https://github.com/conda-forge/conda-smithy/pull/966, https://github.com/conda-forge/staged-recipes/pull/7239, 