### PR TITLE
add spaces in jinja2 references to avoid lint

### DIFF
--- a/run.R
+++ b/run.R
@@ -111,6 +111,9 @@ for (fn in packages) {
     meta_new <- meta_new[-(sha256_line - 1)]
   }
 
+  # Space at beginning and end of jinja variable references
+  meta_new <- str_replace_all(meta_new, '\\{\\{ *([^} ]+) *\\}\\}', '{{ \\1 }}')
+
   # Add back CRAN metadata
   meta_new <- c(meta_new, "", cran_metadata)
 

--- a/run.py
+++ b/run.py
@@ -107,6 +107,9 @@ for fn in packages:
             # Add a blank line before a new section
             line = re.sub('^[a-z]', '\n\g<0>', line)
 
+            # Space at beginning and end of jinja variable references
+            line = re.sub('\{\{ *([^} ]+) *\}\}', '{{ \g<1> }}', line)
+
             meta_new += line
 
     # Add maintainers listed in extra.yaml


### PR DESCRIPTION
The conda forge linter has been complaining about jinja2 variable references without spaces, which are generated by `conda skeleton`.  This change ensures that all jinja2 references are surrounded by exactly one space inside the double braces.