### PR TITLE
added regex to change 'license: GPL-2' to 'license: GPL-2.0-or-later'

### DIFF
--- a/run.R
+++ b/run.R
@@ -60,6 +60,13 @@ if (!file.exists("extra.yaml")) {
 
 # Process packages -------------------------------------------------------------
 
+SPDX_url = 'https://conda-forge.org/docs/maintainer/adding_pkgs.html#spdx-identifiers-and-expressions'
+SPDX_licenses = c('Apache-2.0', 'Apache-2.0 WITH LLVM-exception',
+                  'BSD-3-Clause', 'BSD-3-Clause OR MIT', 'GPL-2.0-or-later',
+                  'LGPL-2.0-only OR GPL-2.0-only', 'LicenseRef-HDF5', 'MIT',
+                  'MIT AND BSD-2-Clause', 'PSF-2.0')
+SPDX_regex = "^\\s+license: +(.+)\\s*"
+
 packages <- readLines("packages.txt")
 
 for (fn in packages) {
@@ -94,6 +101,16 @@ for (fn in packages) {
 
   # Changing GLP-2 to GPL-2.0-or-later
   meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-or-later")
+
+  # Checking for valid license
+  for(line in meta_new){
+    if(grepl(SPDX_regex, line)){
+      license <- str_replace(line, SPDX_regex, '\\1')
+      if(! license %in% SPDX_licenses){
+        stop(license, " license not valid. See ", SPDX_url)
+      }
+    }
+  }
 
   # Add maintainers listed in extra.yaml
   maintainers <- readLines("extra.yaml")

--- a/run.R
+++ b/run.R
@@ -92,6 +92,9 @@ for (fn in packages) {
   # Remove "+ file LICENSE" or "+ file LICENCE"
   meta_new <- str_replace(meta_new, " [+|] file LICEN[SC]E", "")
 
+  # Changing GLP-2 to GPL-2.0-or-later
+  meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-or-later")
+
   # Add maintainers listed in extra.yaml
   maintainers <- readLines("extra.yaml")
   meta_new <- c(meta_new, maintainers)

--- a/run.py
+++ b/run.py
@@ -104,6 +104,9 @@ for fn in packages:
             # Remove '+ file LICENSE' or '+ file LICENCE'
             line = re.sub(' [+|] file LICEN[SC]E', '', line)
 
+            # Changing GLP-2 to GPL-2.0-or-later
+            line = re.sub('license: GPL-2$', 'license: GPL-2.0-or-later', line)
+
             # Add a blank line before a new section
             line = re.sub('^[a-z]', '\n\g<0>', line)
 

--- a/run.py
+++ b/run.py
@@ -64,6 +64,13 @@ if not os.path.isfile('extra.yaml'):
 
 # Process packages -------------------------------------------------------------
 
+SPDX_url = 'https://conda-forge.org/docs/maintainer/adding_pkgs.html#spdx-identifiers-and-expressions'
+SPDX_licenses = {'Apache-2.0', 'Apache-2.0 WITH LLVM-exception',
+                 'BSD-3-Clause', 'BSD-3-Clause OR MIT', 'GPL-2.0-or-later',
+                 'LGPL-2.0-only OR GPL-2.0-only', 'LicenseRef-HDF5', 'MIT',
+                 'MIT AND BSD-2-Clause', 'PSF-2.0'}
+SPDX_regex = re.compile(r'^\s+license: +(.+)\s*')
+
 with open('packages.txt', 'r') as f:
    packages = f.readlines()
    packages = [x.strip() for x in packages]
@@ -106,6 +113,13 @@ for fn in packages:
 
             # Changing GLP-2 to GPL-2.0-or-later
             line = re.sub('license: GPL-2$', 'license: GPL-2.0-or-later', line)
+
+            # Checking for valid SPDX license
+            if SPDX_regex.match(line):
+                license = SPDX_regex.match(line).group(1)
+                if not license in SPDX_licenses:
+                    msg = '"{}" license not valid. See {}'
+                    raise ValueError(msg.format(license, SPDX_url))
 
             # Add a blank line before a new section
             line = re.sub('^[a-z]', '\n\g<0>', line)


### PR DESCRIPTION
Here's the PR for the regex to deal with the GPL naming issue. I'll work on adding a check for a valid SPDX identifier next.