### PR TITLE
Use new CRAN skeleton flag `--no-comments` and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ process. Also, please only submit one recipe per Pull Request.
 
 ## Installation
 
-You will need conda and conda-build 3 (3.17.2+) installed:
+You will need conda and conda-build 3 (3.18.10+) installed:
 
 ```
 conda install -c conda-forge conda-build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ process. Also, please only submit one recipe per Pull Request.
 
 ## Installation
 
-You will need conda and conda-build 3 (3.21.0+) installed:
+You will need conda and conda-build 3 (3.21.6+) installed:
 
 ```
 conda install -c conda-forge conda-build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ process. Also, please only submit one recipe per Pull Request.
 
 ## Installation
 
-You will need conda and conda-build 3 (3.18.10+) installed:
+You will need conda and conda-build 3 (3.21.0+) installed:
 
 ```
 conda install -c conda-forge conda-build

--- a/run.R
+++ b/run.R
@@ -40,8 +40,8 @@ if (!grepl(pattern = "conda-build 3.+", conda_build_version)) {
 
 conda_build_version_num <- str_extract(conda_build_version,
                                        "\\d+\\.\\d+\\.\\d+")
-if (compareVersion(conda_build_version_num, "3.17.2") == -1) {
-  stop("You need to install conda-build 3.17.2 or later.",
+if (compareVersion(conda_build_version_num, "3.18.10") == -1) {
+  stop("You need to install conda-build 3.18.10 or later.",
        "\nCurrently installed version: ", conda_build_version_num,
        "\nRun: conda install -c conda-forge conda-build")
 }
@@ -92,9 +92,6 @@ for (fn in packages) {
 
   # Remove comments
   meta_new <- meta_new[!str_detect(meta_new, "^\\s*#")]
-
-  # Remove "+ file LICENSE" or "+ file LICENCE"
-  meta_new <- str_replace(meta_new, " [+|] file LICEN[SC]E", "")
 
   # Changing GLP-2 to GPL-2.0-or-later
   meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-or-later")

--- a/run.R
+++ b/run.R
@@ -40,8 +40,8 @@ if (!grepl(pattern = "conda-build 3.+", conda_build_version)) {
 
 conda_build_version_num <- str_extract(conda_build_version,
                                        "\\d+\\.\\d+\\.\\d+")
-if (compareVersion(conda_build_version_num, "3.18.10") == -1) {
-  stop("You need to install conda-build 3.18.10 or later.",
+if (compareVersion(conda_build_version_num, "3.21.0") == -1) {
+  stop("You need to install conda-build 3.21.0 or later.",
        "\nCurrently installed version: ", conda_build_version_num,
        "\nRun: conda install -c conda-forge conda-build")
 }

--- a/run.R
+++ b/run.R
@@ -111,19 +111,14 @@ for (fn in packages) {
   maintainers <- readLines("extra.yaml")
   meta_new <- c(meta_new, maintainers)
 
-  # Remove any consecutive empty lines
-  meta_new <- rle(meta_new)$values
+  # Remove blank lines
+  blank_lines <- meta_new == ""
+  meta_new <- meta_new[!blank_lines]
 
-  # Remove the annoying blank line in the jinja templating section
-  jinja_version_line <- str_which(meta_new, "set version")
-  if (meta_new[jinja_version_line + 1] == "") {
-    meta_new <- meta_new[-(jinja_version_line + 1)]
-  }
-
-  # Remove the annoying blank line between url and sha256
-  sha256_line <- str_which(meta_new, "^  sha256")
-  if (meta_new[sha256_line - 1] == "") {
-    meta_new <- meta_new[-(sha256_line - 1)]
+  # Add a blank line before a new section
+  sections <- str_which(meta_new, "^[a-z]")
+  for (s in rev(sections)) {
+    meta_new <- c(meta_new[1:(s - 1)], "", meta_new[s:length(meta_new)])
   }
 
   # Space at beginning and end of jinja variable references

--- a/run.py
+++ b/run.py
@@ -43,9 +43,9 @@ if not re.match('^3.+', conda_build_version):
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)
 
-v_min = StrictVersion('3.17.2')
+v_min = StrictVersion('3.18.10')
 if StrictVersion(conda_build_version) < v_min:
-    sys.stderr.write('You need to install conda-build 3.17.2 or later.\n')
+    sys.stderr.write('You need to install conda-build 3.18.10 or later.\n')
     sys.stderr.write(f'Currently installed version: {conda_build_version}\n')
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)
@@ -105,9 +105,6 @@ for fn in packages:
             # Remove comments and blank lines
             if re.match('^\s*#', line) or re.match('^\n$', line):
                 continue
-
-            # Remove '+ file LICENSE' or '+ file LICENCE'
-            line = re.sub(' [+|] file LICEN[SC]E', '', line)
 
             # Changing GLP-2 to GPL-2.0-or-later
             line = re.sub('license: GPL-2$', 'license: GPL-2.0-or-later', line)

--- a/run.py
+++ b/run.py
@@ -43,9 +43,9 @@ if not re.match('^3.+', conda_build_version):
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)
 
-v_min = StrictVersion('3.18.10')
+v_min = StrictVersion('3.21.0')
 if StrictVersion(conda_build_version) < v_min:
-    sys.stderr.write('You need to install conda-build 3.18.10 or later.\n')
+    sys.stderr.write('You need to install conda-build 3.21.0 or later.\n')
     sys.stderr.write(f'Currently installed version: {conda_build_version}\n')
     sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
     sys.exit(1)


### PR DESCRIPTION
The main update in this PR is using the new flag `--no-comments` that I added upstream to the CRAN skeleton in https://github.com/conda/conda-build/pull/4302. It was recently released in conda-build [3.21.6](https://github.com/conda/conda-build/releases/tag/3.21.6), and is already available from conda-forge.

I also made a few other minor updates:

* Removed the code that removed `+| LICENSE` since this is no longer necessary
* Modified `run.R` to handle blank lines the same as `run.py`

I confirmed that the output recipe files are identical to the current behavior by `diff`ing the recipes in `packages.txt` before and after making these updates.