### PR TITLE
Allow creating recipes for archived CRAN packages.

### DIFF
--- a/run.R
+++ b/run.R
@@ -78,7 +78,7 @@ for (fn in packages) {
 
   # Create the recipe using the cran skeleton
   system2("conda", args = c("skeleton", "cran", "--use-noarch-generic",
-                            "--add-cross-r-base", "--no-comments", fn))
+                            "--add-cross-r-base", "--no-comments", "--allow-archived", fn))
 
   # Edit meta.yaml -------------------------------------------------------------
 

--- a/run.py
+++ b/run.py
@@ -86,7 +86,7 @@ for fn in packages:
 
     # Create the recipe using the cran skeleton
     sp.run(['conda', 'skeleton', 'cran', '--use-noarch-generic',
-            '--add-cross-r-base', '--no-comments', fn])
+            '--add-cross-r-base', '--no-comments', '--allow-archived', fn])
 
     # Edit meta.yaml -------------------------------------------------------------
 


### PR DESCRIPTION
Creating recipes for archived CRAN packages can be useful, e.g. I typically use it to update recipes in existing conda-forge feedstocks.