### PR TITLE
Change GPL-2 to GPL-2.0-only instead of GPL-2.0-or-later

### DIFF
--- a/run.R
+++ b/run.R
@@ -93,8 +93,8 @@ for (fn in packages) {
   cran_metadata <- cran_metadata[str_detect(cran_metadata, "^#\\s[A-Z]\\S+:")]
   meta_new <- meta_new[-cran_metadata_lines]
 
-  # Changing GLP-2 to GPL-2.0-or-later
-  meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-or-later")
+  # Changing GPL-2 to GPL-2.0-only
+  meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-only")
 
   # Checking for valid license
   for(line in meta_new){

--- a/run.py
+++ b/run.py
@@ -108,8 +108,8 @@ for fn in packages:
             if re.match('^\n$', line):
                 continue
 
-            # Changing GLP-2 to GPL-2.0-or-later
-            line = re.sub('license: GPL-2$', 'license: GPL-2.0-or-later', line)
+            # Changing GPL-2 to GPL-2.0-only
+            line = re.sub('license: GPL-2$', 'license: GPL-2.0-only', line)
 
             # Checking for valid SPDX license
             if SPDX_regex.match(line):


### PR DESCRIPTION
R packages have the license key "GPL (>= 2)" for GPL-2.0-or-later (see https://r-pkgs.org/license.html#key-files). Nothing indicates that "GPL-2" should include later versions of the GPL.