### PR TITLE
drop conda-build v3 test

### DIFF
--- a/run.R
+++ b/run.R
@@ -33,11 +33,6 @@ if (conda_build == "") {
 
 conda_build_version <- system2("conda", args = c("build", "--version"),
                                stdout = TRUE)
-if (!grepl(pattern = "conda-build 3.+", conda_build_version)) {
-  stop("You need to install conda-build 3 from the conda-forge channel",
-       "\nRun: conda install -c conda-forge conda-build")
-}
-
 conda_build_version_num <- str_extract(conda_build_version,
                                        "\\d+\\.\\d+\\.\\d+")
 if (compareVersion(conda_build_version_num, "3.21.6") == -1) {

--- a/run.py
+++ b/run.py
@@ -38,11 +38,6 @@ if not shutil.which('conda-build'):
 import conda_build
 
 conda_build_version = conda_build.__version__
-if not re.match('^3.+', conda_build_version):
-    sys.stderr.write('You need to install conda-build 3 from the conda-forge channel\n')
-    sys.stderr.write('Run: conda install -c conda-forge conda-build\n')
-    sys.exit(1)
-
 v_min = StrictVersion('3.21.6')
 if StrictVersion(conda_build_version) < v_min:
     sys.stderr.write('You need to install conda-build 3.21.6 or later.\n')


### PR DESCRIPTION
The `conda-build` package has switched to calendar versioning (`24.1.2`), but the scripts here enforce v3. This PR drops the `conda-build==3.*` testing, but leaves the minimum check (`>= 3.21.6`) in place. I've verified both Python and R scripts work for `r-matrix` using `conda-build=24.1.2`.

Closes #61.