### PR TITLE
UCRT Updates

### DIFF
--- a/run.R
+++ b/run.R
@@ -84,9 +84,13 @@ for (fn in packages) {
   # UCRT changes
   meta_new <- str_replace(meta_new, fixed("{{ native }}"), "")
   meta_new <- str_replace(meta_new, fixed("{{native}}"), "")
+  meta_new <- str_replace(meta_new, fixed("{{ posix }}pkg-config"), "pkg-config")
+  meta_new <- str_replace(meta_new, fixed("{{posix}}pkg-config"), "pkg-config")
+  meta_new <- str_replace(meta_new, fixed("- m2w64-pkg-config"), "pkg-config")
+  meta_new <- str_replace(meta_new, fixed("- m2w64-toolchain"), "- {{ compiler('m2w64_c') }}")
+  meta_new <- str_replace(meta_new, fixed("- posix"), "- m2-base")
   meta_new <- meta_new[!str_detect(meta_new, fixed("merge_build_host: "))]
   meta_new <- meta_new[!str_detect(meta_new, fixed("- gcc-libs"))]
-  meta_new <- meta_new[!str_detect(meta_new, fixed("- posix"))]
   meta_new <- meta_new[!str_detect(meta_new, fixed("set native ="))]
   
   # Extract CRAN metadata

--- a/run.R
+++ b/run.R
@@ -81,6 +81,14 @@ for (fn in packages) {
   meta_raw <- readLines(meta_fname)
   meta_new <- meta_raw
 
+  # UCRT changes
+  meta_new <- str_replace(meta_new, fixed("{{ native }}"), "")
+  meta_new <- str_replace(meta_new, fixed("{{native}}"), "")
+  meta_new <- meta_new[!str_detect(meta_new, fixed("merge_build_host: "))]
+  meta_new <- meta_new[!str_detect(meta_new, fixed("- gcc-libs"))]
+  meta_new <- meta_new[!str_detect(meta_new, fixed("- posix"))]
+  meta_new <- meta_new[!str_detect(meta_new, fixed("set native ="))]
+  
   # Extract CRAN metadata
   cran_metadata_start <- str_which(meta_new, "^# Package: ")
   cran_metadata_lines <- cran_metadata_start:length(meta_new)

--- a/run.R
+++ b/run.R
@@ -86,7 +86,7 @@ for (fn in packages) {
   meta_new <- str_replace(meta_new, fixed("{{native}}"), "")
   meta_new <- str_replace(meta_new, fixed("{{ posix }}pkg-config"), "pkg-config")
   meta_new <- str_replace(meta_new, fixed("{{posix}}pkg-config"), "pkg-config")
-  meta_new <- str_replace(meta_new, fixed("- m2w64-pkg-config"), "pkg-config")
+  meta_new <- str_replace(meta_new, fixed("- m2w64-pkg-config"), "- pkg-config")
   meta_new <- str_replace(meta_new, fixed("- m2w64-toolchain"), "- {{ compiler('m2w64_c') }}")
   meta_new <- str_replace(meta_new, fixed("- posix"), "- m2-base")
   meta_new <- meta_new[!str_detect(meta_new, fixed("merge_build_host: "))]

--- a/run.py
+++ b/run.py
@@ -96,11 +96,14 @@ for fn in packages:
             # UCRT changes
             line = line.replace("{{ native }}", "")
             line = line.replace("{{native}}", "")
+            line = line.replace("{{posix}}pkg-config", "pkg-config")
+            line = line.replace("{{ posix }}pkg-config", "pkg-config")
+            line = line.replace("- m2w64-pkg-config", "- pkg-config")
+            line = line.replace("- m2w64-toolchain", "- {{ compiler('m2w64_c') }}")
+            line = line.replace("- posix", "- m2-base")
             if "merge_build_host: " in line:
                 continue
             if "- gcc-libs" in line:
-                continue
-            if "- posix" in line:
                 continue
             if "set native =" in line:
                 continue

--- a/run.py
+++ b/run.py
@@ -92,6 +92,18 @@ for fn in packages:
         cran_metadata = ['\n']
 
         for line in f:
+            # UCRT changes
+            line = line.replace("{{ native }}", "")
+            line = line.replace("{{native}}", "")
+            if "merge_build_host: " in line:
+                continue
+            if "- gcc-libs" in line:
+                continue
+            if "- posix" in line:
+                continue
+            if "set native =" in line:
+                continue
+            
             # Extract CRAN metadata
             if line[:11] == '# Package: ':
                 is_cran_metadata = True


### PR DESCRIPTION
UCRT builds require some recipe changes. Basically, strict following of @isuruf's [implementation for the migrator](https://github.com/regro/cf-scripts/blob/8b5b38e64768066ece62349e3ead0bbe464da78e/conda_forge_tick/migrators/r_ucrt.py#L15-L24).

Closes #63.

Leaving as Draft for now, since I believe we should wait until post-migration to make this default format for incoming recipes.