### PR TITLE
inject missing_dso_whitelist

### DIFF
--- a/run.R
+++ b/run.R
@@ -88,6 +88,18 @@ for (fn in packages) {
   cran_metadata <- cran_metadata[str_detect(cran_metadata, "^#\\s[A-Z]\\S+:")]
   meta_new <- meta_new[-cran_metadata_lines]
 
+  # Inject missing_dso_whitelist
+  # NB: this can be removed if merge of https://github.com/conda/conda-build/pull/4786
+  idx_rpaths_start <- which(str_detect(meta_new, "  rpaths:"))
+  idx_rpaths_end <- which(meta_new == "")
+  idx_rpaths_end <- idx_rpaths_end[idx_rpaths_end > idx_rpaths_start][1]
+  meta_new <- c(meta_new[seq(idx_rpaths_end - 1)],
+                "  missing_dso_whitelist:",
+                "    - '*/R.dll'        # [win]",
+                "    - '*/Rblas.dll'    # [win]",
+                "    - '*/Rlapack.dll'  # [win]",
+                meta_new[seq(idx_rpaths_end, length(meta_new))])
+  
   # Changing GPL-2 to GPL-2.0-only
   meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-only")
 

--- a/run.py
+++ b/run.py
@@ -90,6 +90,7 @@ for fn in packages:
         meta_new = []
         is_cran_metadata = False
         cran_metadata = ['\n']
+        is_rpaths = False
 
         for line in f:
             # Extract CRAN metadata
@@ -98,6 +99,24 @@ for fn in packages:
             if is_cran_metadata and re.match('^#\s[A-Z]\S+:', line):
                 cran_metadata += line
                 continue
+            
+            # Inject missing_dso_whitelist
+            # NB: this can be removed if merge of https://github.com/conda/conda-build/pull/4786
+            if re.match('^  rpaths:$', line):
+                is_rpaths = True
+                meta_new += line
+                continue
+            elif is_rpaths:
+                if re.match('^\s+-.*', line):
+                    meta_new += line
+                    continue
+                else:
+                    is_rpaths = False
+                    meta_new += "  missing_dso_whitelist:\n"
+                    meta_new += "    - '*/R.dll'        # [win]\n"
+                    meta_new += "    - '*/Rblas.dll'    # [win]\n"
+                    meta_new += "    - '*/Rlapack.dll'  # [win]\n"
+                    continue
 
             # Remove blank lines
             if re.match('^\n$', line):


### PR DESCRIPTION
This addresses an outstanding issue that package submitters to Conda Forge's **staged-recipes** confront due to the use of `error_overlinking: true`. In particular, dynamic libraries under the Windows R `lib` are not by default regarded as guaranteed by the run requirements, leading to an error. [A PR has been submitted](https://github.com/conda/conda-build/pull/4786) to `conda-build` that would (partially) resolve this, but has been sitting unmerged.

This PR proposes to give more immediate relief for recipe submitters (and reviewers) and includes a comment for when it can be removed.

Resolves #65