### PR TITLE
Fix "Warning: 'GPL-3' license not valid." by using the same trick as for GPL-2

### DIFF
--- a/run.R
+++ b/run.R
@@ -114,6 +114,8 @@ for (fn in packages) {
   
   # Changing GPL-2 to GPL-2.0-only
   meta_new <- str_replace(meta_new, "license: GPL-2$", "license: GPL-2.0-only")
+  # Changing GPL-3 to GPL-3.0-only
+  meta_new <- str_replace(meta_new, "license: GPL-3$", "license: GPL-3.0-only")
 
   # Checking for valid license
   for(line in meta_new){

--- a/run.py
+++ b/run.py
@@ -139,6 +139,9 @@ for fn in packages:
 
             # Changing GPL-2 to GPL-2.0-only
             line = re.sub('license: GPL-2$', 'license: GPL-2.0-only', line)
+	    # Changing GPL-3 to GPL-3.0-only
+            line = re.sub('license: GPL-3$', 'license: GPL-3.0-only', line)
+
 
             # Checking for valid SPDX license
             if SPDX_regex.match(line):


### PR DESCRIPTION
I have slightly modify both the python ans the R script to adapt to GPL-3 license.